### PR TITLE
Add support for platformio

### DIFF
--- a/extra_script.py
+++ b/extra_script.py
@@ -1,0 +1,14 @@
+import os
+
+env = DefaultEnvironment()
+
+# An extra script is required to properly handle extra link flags set in
+# the `library.properties` file
+if env.BoardConfig().get("build.mcu", "").startswith("nrf5284"):
+    env.Append(
+        LIBPATH=[os.path.realpath("src/cortex-m4/fpv4-sp-d16-hard")],
+        LIBS=["nrf_cc310_0.9.13-no-interrupts"]
+    )
+    env.Append(
+        CPPDEFINES=[("NRF_CRYPTOCELL", "((NRF_CRYPTOCELL_Type*) NRF_CRYPTOCELL_BASE)")],
+    )

--- a/library.json
+++ b/library.json
@@ -1,0 +1,6 @@
+{
+    "name": "Adafruit nRFCrypto",
+    "build": {
+        "extraScript": "extra_script.py"
+    }
+}


### PR DESCRIPTION
When using the platformio repository to pull in the Adafruit nrf52 framework, it manually adds the below `library.json` and `extra_script.py` for the the pio LDF. This is required for the linker to have all dependencies and has been an issue discussed several times (e.g. [here](https://community.platformio.org/t/precompiled-library-issue-with-nrfcrypto/35660) or [here](https://community.platformio.org/t/building-with-non-release-platform-package-framework-results-in-dependency-assertion-error/35439/7).

In this "parent" repository it was suggested to me [to make a PR for supporting pio](https://github.com/adafruit/Adafruit_nRF52_Arduino/issues/787), which I am doing with this as a first step. TinyUSB is next, if this is seen as reasonable to do.

Looking forward to your feedback!

